### PR TITLE
Added the mutable flag that is required as of Android 12, also bumped driver version to 3.5.0 enabling support for generic CDC driver

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-serialusb" version="0.0.1"
+<plugin id="cordova-plugin-serialusb" version="0.0.2"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Serial USB</name>

--- a/src/android/SerialUSB.java
+++ b/src/android/SerialUSB.java
@@ -213,7 +213,7 @@ public class SerialUSB extends CordovaPlugin {
 					driver = availableDrivers.get(0);
 					UsbDevice device = driver.getDevice();
 					// create the intent that will be used to get the permission
-					PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity(), 0, new Intent(UsbBroadcastReceiver.USB_PERMISSION), 0);
+					PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity(), 0, new Intent(UsbBroadcastReceiver.USB_PERMISSION), PendingIntent.FLAG_MUTABLE);
 					// and a filter on the permission we ask
 					IntentFilter filter = new IntentFilter();
 					filter.addAction(UsbBroadcastReceiver.USB_PERMISSION);

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.mik3y:usb-serial-for-android:3.4.1'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.5.0'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.mik3y:usb-serial-for-android:3.4.0'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.4.1'
 }


### PR DESCRIPTION
Source for Android 12 mutable flag:

https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE

This is where I got the idea for adding generic CDC driver from:

https://github.com/kai-morich/SimpleUsbTerminal/commit/e0e1313527e45e77cd3b3e80638414bc56c6f6aa